### PR TITLE
add error handler for session

### DIFF
--- a/src/APNPushProvider.ts
+++ b/src/APNPushProvider.ts
@@ -59,6 +59,10 @@ export class APNPushProvider {
   private ensureConnected() {
     if (!this.session || this.session.destroyed) {
       this.session = http2.connect(this.options.production ? AuthorityAddress.production : AuthorityAddress.development);
+      this.session.on('error', (err) => {
+        // Swallow error event to prevent unhandled 'error' event exception.
+        // Assume session has been destroyed and will be recreated on subsequent call to ensureConnected.
+      });
     }
   }
 


### PR DESCRIPTION
Since the addition of the error handler my app hasn't crashed for over a month, where previously it was crashing from an unhandled error:

```
2018-10-20T17:05:55.807001175Z       throw er; // Unhandled 'error' event
2018-10-20T17:05:55.807007024Z       ^
2018-10-20T17:05:55.807011249Z 
2018-10-20T17:05:55.807015403Z Error: read ETIMEDOUT
2018-10-20T17:05:55.807019232Z     at TLSWrap.onStreamRead (internal/stream_base_commons.js:111:27)
2018-10-20T17:05:55.807023057Z 
2018-10-20T17:05:55.807026222Z Emitted 'error' event at:
2018-10-20T17:05:55.807029497Z     at emitClose (internal/http2/core.js:818:10)
2018-10-20T17:05:55.807032856Z     at process._tickCallback (internal/process/next_tick.js:63:19)
2018-10-20T17:05:55.807036319Z
``` 
As per the code comment, I'm unsure about the session lifecycle, so I'd appreciate any feedback as to whether it may be necessary to take further action to clean up the session in the handler.